### PR TITLE
Run DetectMateService integration tests from library CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install project deps
         run: uv pip install .[dev]
 
+      - name: Run pre-commit with prek
+        run: uv run prek run -a
+
       - name: Test with pytest
         run: uv run pytest
 


### PR DESCRIPTION
To ensure that changes in the library won't break the components running as a service. Right now there are the following integration tests in the service's tests/library_integration folder:

- single component integration for: 
  - `LogFileReader`
  - `DummyParser`
  - `DummyDetector`
- pipeline for (where the output of one component is the input for the next):
  -  `test_logs.log` --> `LogFileReader` --> `DummyParser` --> `DummyDetector`
  - `audit.log` --> `LogFileReader` --> `MatcherParser` --> `NewValueDetector`


\+ added running prek too