### PR TITLE
Add pre-commit Mypy schema exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   hooks:
     - id: mypy
       args: [--strict, --ignore-missing-imports]
-      exclude: ^(docs/|tests/|src/detectmatelibrary/schemas/.*_pb2\.py)
+      exclude: ^(docs/|tests/)
       additional_dependencies:
         - pydantic
         - types-PyYAML

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ where = ["src"]
 
 [project.scripts]
 mate = "tools.workspace.create_workspace:main"
+
+[[tool.mypy.overrides]]
+module = "detectmatelibrary.schemas.schemas_pb2"
+ignore_errors = true


### PR DESCRIPTION
Regenerating schemas with protoc removes the mypy ignore comment. This works universally for all schemas.