### PR TITLE
prevent cross event comparison for NVD and NVCD

### DIFF
--- a/src/detectmatelibrary/detectors/new_value_combo_detector.py
+++ b/src/detectmatelibrary/detectors/new_value_combo_detector.py
@@ -95,14 +95,17 @@ class NewValueComboDetector(CoreDetector):
         combo_dict = get_combo(configured_variables)
 
         overall_score = 0.0
-        for event_id, event_tracker in self.persistency.get_events_data().items():
+        current_event_id = input_["EventID"]
+        known_events = self.persistency.get_events_data()
+
+        if current_event_id in known_events:
+            event_tracker = known_events[current_event_id]
             for combo_key, multi_tracker in event_tracker.get_data().items():
-                # Get the value tuple for this combo key
                 value_tuple = combo_dict.get(combo_key)
                 if value_tuple is None:
                     continue
                 if value_tuple not in multi_tracker.unique_set:
-                    alerts[f"EventID {event_id}"] = (
+                    alerts[f"EventID {current_event_id} - {combo_key}"] = (
                         f"Unknown value combination: {value_tuple}"
                     )
                     overall_score += 1.0

--- a/src/detectmatelibrary/detectors/new_value_detector.py
+++ b/src/detectmatelibrary/detectors/new_value_detector.py
@@ -59,13 +59,17 @@ class NewValueDetector(CoreDetector):
         configured_variables = get_configured_variables(input_, self.config.events)
         overall_score = 0.0
 
-        for event_id, event_tracker in self.persistency.get_events_data().items():
-            for event_id, multi_tracker in event_tracker.get_data().items():
-                value = configured_variables.get(event_id)
+        current_event_id = input_["EventID"]
+        known_events = self.persistency.get_events_data()
+
+        if current_event_id in known_events:
+            event_tracker = known_events[current_event_id]
+            for var_name, multi_tracker in event_tracker.get_data().items():
+                value = configured_variables.get(var_name)
                 if value is None:
                     continue
                 if value not in multi_tracker.unique_set:
-                    alerts[f"EventID {event_id}"] = (
+                    alerts[f"EventID {current_event_id} - {var_name}"] = (
                         f"Unknown value: '{value}'"
                     )
                     overall_score += 1.0

--- a/src/detectmatelibrary/utils/persistency/event_persistency.py
+++ b/src/detectmatelibrary/utils/persistency/event_persistency.py
@@ -58,7 +58,23 @@ class EventPersistency:
         return data_structure.get_data() if data_structure is not None else None
 
     def get_events_data(self) -> Dict[int, EventDataStructure]:
-        """Retrieve the events' data."""
+        """Retrieve the events data that is currently stored.
+
+        Returns:
+            A dictionary mapping event IDs to their corresponding EventDataStructure instances.
+
+            Example:
+            {
+                1: EventTracker(data={
+                    'var_0': SingleTracker(...),
+                    'var_1': SingleTracker(...),
+                }),
+                2: EventTracker(data={
+                    'var_0': SingleTracker(...)
+                }),
+                ...
+            }
+        """
         return self.events_data
 
     def get_event_template(self, event_id: int) -> str | None:

--- a/tests/test_detectors/test_new_value_combo_detector.py
+++ b/tests/test_detectors/test_new_value_combo_detector.py
@@ -3,6 +3,8 @@ from detectmatelibrary.detectors.new_value_combo_detector import (
     NewValueComboDetector, BufferMode
 )
 from detectmatelibrary.common._config import generate_detector_config
+from detectmatelibrary.parsers.template_matcher import MatcherParser
+from detectmatelibrary.helper.from_to import From
 import detectmatelibrary.schemas as schemas
 
 from detectmatelibrary.utils.aux import time_test_mode
@@ -541,3 +543,46 @@ class TestNewValueComboDetectorEndToEnd:
         output = schemas.DetectorSchema()
         result = detector.detect(file_event, output)
         assert result is False
+
+
+_PARSER_CONFIG = {
+    "parsers": {
+        "MatcherParser": {
+            "method_type": "matcher_parser",
+            "auto_config": False,
+            "log_format": "type=<Type> msg=audit\\(<Time>\\): <Content>",
+            "time_format": None,
+            "params": {
+                "remove_spaces": True,
+                "remove_punctuation": True,
+                "lowercase": True,
+                "path_templates": "tests/test_folder/audit_templates.txt",
+            },
+        }
+    }
+}
+
+
+class TestNewValueComboDetectorEndToEndWithRealData:
+    """Regression test: full configure/train/detect pipeline on audit.log."""
+
+    def test_audit_log_anomalies(self):
+        parser = MatcherParser(config=_PARSER_CONFIG)
+        detector = NewValueComboDetector()
+
+        logs = list(From.log(parser, in_path="tests/test_folder/audit.log", do_process=True))
+
+        for log in logs[:1800]:
+            detector.configure(log)
+        detector.set_configuration()
+
+        for log in logs[:1800]:
+            detector.train(log)
+
+        detected_ids: set[str] = set()
+        for log in logs[1800:]:
+            output = schemas.DetectorSchema()
+            if detector.detect(log, output_=output):
+                detected_ids.add(log["logID"])
+
+        print(detected_ids)

--- a/tests/test_detectors/test_new_value_detector.py
+++ b/tests/test_detectors/test_new_value_detector.py
@@ -9,6 +9,8 @@ This module tests the NewValueDetector implementation including:
 """
 
 from detectmatelibrary.detectors.new_value_detector import NewValueDetector, BufferMode
+from detectmatelibrary.parsers.template_matcher import MatcherParser
+from detectmatelibrary.helper.from_to import From
 import detectmatelibrary.schemas as schemas
 
 from detectmatelibrary.utils.aux import time_test_mode
@@ -188,3 +190,46 @@ class TestNewValueDetectorDetection:
 
         assert result
         assert output.score == 1.0
+
+
+_PARSER_CONFIG = {
+    "parsers": {
+        "MatcherParser": {
+            "method_type": "matcher_parser",
+            "auto_config": False,
+            "log_format": "type=<Type> msg=audit\\(<Time>\\): <Content>",
+            "time_format": None,
+            "params": {
+                "remove_spaces": True,
+                "remove_punctuation": True,
+                "lowercase": True,
+                "path_templates": "tests/test_folder/audit_templates.txt",
+            },
+        }
+    }
+}
+
+
+class TestNewValueDetectorEndToEnd:
+    """Regression test: full configure/train/detect pipeline on audit.log."""
+
+    def test_audit_log_anomalies(self):
+        parser = MatcherParser(config=_PARSER_CONFIG)
+        detector = NewValueDetector()
+
+        logs = list(From.log(parser, in_path="tests/test_folder/audit.log", do_process=True))
+
+        for log in logs[:1800]:
+            detector.configure(log)
+        detector.set_configuration()
+
+        for log in logs[:1800]:
+            detector.train(log)
+
+        detected_ids: set[str] = set()
+        for log in logs[1800:]:
+            output = schemas.DetectorSchema()
+            if detector.detect(log, output_=output):
+                detected_ids.add(log["logID"])
+
+        assert detected_ids == {'1859', '1860', '1861', '1862', '1864', '1865', '1866', '1867'}


### PR DESCRIPTION
There was an issue with values or value-combos being compared across different event_ids leading to incorrectly labelled logs. This has now been fixed.