### PR TITLE
auto_load true start without saved state on first boot

### DIFF
--- a/detectmatelibrary_tests/test_utils/test_persistency_saver.py
+++ b/detectmatelibrary_tests/test_utils/test_persistency_saver.py
@@ -223,6 +223,14 @@ class TestPersistencySaverTriggers:
         PersistencySaver(p2, PersistencySaverConfig(path="memory://autoload/state", auto_load=True))
         assert "E1" in p2.get_events_seen()
 
+    def test_auto_load_on_init_no_state_starts_fresh(self):
+        # auto_load=True with no prior save must not crash but starts with empty state
+        p = EventPersistency(event_data_class=EventDataFrame)
+        saver = PersistencySaver(p, PersistencySaverConfig(path="memory://autoload/state", auto_load=True))
+        assert len(p.get_events_seen()) == 0
+        assert len(p.get_events_data()) == 0
+        assert saver is not None
+
 
 class TestPersistencySaverIntegration:
     def test_full_cycle_dataframe_backend(self):

--- a/detectmatelibrary_tests/test_utils/test_persistency_saver.py
+++ b/detectmatelibrary_tests/test_utils/test_persistency_saver.py
@@ -226,7 +226,8 @@ class TestPersistencySaverTriggers:
     def test_auto_load_on_init_no_state_starts_fresh(self):
         # auto_load=True with no prior save must not crash but starts with empty state
         p = EventPersistency(event_data_class=EventDataFrame)
-        saver = PersistencySaver(p, PersistencySaverConfig(path="memory://autoload/state", auto_load=True))
+        cfg = PersistencySaverConfig(path="memory://autoload_no_prior_state/state", auto_load=True)
+        saver = PersistencySaver(p, cfg)
         assert len(p.get_events_seen()) == 0
         assert len(p.get_events_data()) == 0
         assert saver is not None

--- a/src/detectmatelibrary/utils/persistency/persistency_saver.py
+++ b/src/detectmatelibrary/utils/persistency/persistency_saver.py
@@ -87,7 +87,10 @@ class PersistencySaver:
             persistency.register_on_ingest(self._check_event_count)
 
         if config.auto_load:
-            self.load()
+            try:
+                self.load()
+            except PersistencyLoadError as e:
+                logger.info(f"PersistencySaver: auto_load enabled but no state found, start fresh.({e})")
 
     def save(self) -> None:
         """Write full EventPersistency state to storage.


### PR DESCRIPTION
# Task
#178 

# Description
Catch PersistencyLoadError during the auto-load init and log an info message instead of raising:

# How Has This Been Tested?
new unit test in detectmatelibrary_tests/test_utils/test_persistency_saver.py

  Manual end-to-end test (Docker Compose getting-started setup in DetectMateService) on branch https://github.com/ait-detectmate/DetectMateService/tree/feature/persistency-admin-endpoints

1. Added persist: { path: /state, auto_load: true } to container/config/detector_config.yaml with no prior saved state.
2. Started the stack, detector came up cleanly. /admin/persistency/status returned events_seen_count: 0, last_saved_at: null, confirming the first-boot path no longer crashes. 
4. Sent two nginx requests (/hello, /world) to feed training data. Status showed events_seen_count: 2, events_since_save: 4 
5. Called POST /admin/persistency/save. Response {"message": "state saved"}. State files confirmed on disk (metadata.json + *.msgpack). Status showed events_since_save: 0 and last_saved_at populated.
6. Restarted the detector container (docker compose restart detector). After startup, status showed events_seen_count: 2, events_with_data_count: 1. state fully restored via auto_load on restart.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
